### PR TITLE
chore: change eslint-plugin-security extended config in node config

### DIFF
--- a/node.js
+++ b/node.js
@@ -5,7 +5,7 @@
 require("@rushstack/eslint-patch/modern-module-resolution")
 
 module.exports = {
-  extends: ["plugin:security/recommended"],
+  extends: ["plugin:security/recommended-legacy"],
   rules: {
     "no-console": ["error", { allow: ["info", "warn", "error"] }],
   },


### PR DESCRIPTION
The `@ravnhq/eslint-config/node` config was giving an error when adding it to the eslint project config

```bash
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    |     property 'plugins' -> object with constructor 'Object'
    |     property 'security' -> object with constructor 'Object'
    |     property 'configs' -> object with constructor 'Object'
    --- property 'recommended' closes the circle
```

This was because we were using the wrong setting for the plugin `eslint-plugin-security` based on the supported `eslint` version.

Check the [documentation for eslint-plugin-security version 2.1.1](https://github.com/eslint-community/eslint-plugin-security/tree/779da2bafde5087506c3682d07b14bd5318e01e0?tab=readme-ov-file#eslintrc-config-deprecated)

Check [relevant issue](https://github.com/eslint-community/eslint-plugin-security/issues/131)
