### PR TITLE
chore: remove deprecated rules from jest config

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -65,7 +65,6 @@ module.exports = {
         "jest/no-if": "error",
         "jest/no-interpolation-in-snapshots": "error",
         "jest/no-jasmine-globals": "off",
-        "jest/no-jest-import": "error",
         "jest/no-large-snapshots": ["warn", { maxSize: 300 }],
         "jest/no-mocks-import": "error",
         "jest/no-restricted-matchers": "off",


### PR DESCRIPTION
Rule `jest/no-jest-import` has been removed from `eslint-plugin-jest` since version `27.0.0` and we're using version `^27.0.1` in the project.

It makes eslint report an error from a non-existent rule being used.

Check [relevant eslint-plugin-jest changelog section](https://github.com/jest-community/eslint-plugin-jest/blob/main/CHANGELOG.md#2700-2022-08-28)